### PR TITLE
Support for using collection of registries in Scraper

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/epimetheus/http4s/Scraper.scala
+++ b/core/src/main/scala/io/chrisdavenport/epimetheus/http4s/Scraper.scala
@@ -6,16 +6,63 @@ import cats.effect._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import io.chrisdavenport.epimetheus.CollectorRegistry
+import io.prometheus.client.exporter.common.TextFormat
+import org.http4s.headers.`Content-Type`
 
 object Scraper {
 
-  def response[F[_]: Functor](cr: CollectorRegistry[F]): F[Response[F]] = 
-    cr.write004.map(Response[F](Status.Ok).withEntity(_))
+  lazy val prometheusContentType: `Content-Type` = `Content-Type`
+    .parse(TextFormat.CONTENT_TYPE_004)
+    .leftMap(_ => `Content-Type`(MediaType.text.plain))
+    .merge
 
-  def routes[F[_]: Sync](cr: CollectorRegistry[F]): HttpRoutes[F] = {
+  private def makeResponse[F[_], T](
+    b: T
+  )(implicit w: EntityEncoder[F, T]
+  ) =
+    Response[F](Status.Ok).withEntity(b).withContentType(prometheusContentType)
+
+  def response[F[_]: Functor](
+    cr: CollectorRegistry[F]
+  ): F[Response[F]] =
+    cr.write004.map(makeResponse(_))
+
+  def response[F[_]: Applicative, T[_]: Foldable](
+    c: T[CollectorRegistry[F]]
+  ): F[Response[F]] =
+    c.foldMapA(_.write004).map(makeResponse(_))
+
+  def responsePar[F[_]: Applicative, T[_]: Foldable](
+    c: T[CollectorRegistry[F]]
+  )(implicit p: Parallel[F]
+  ): F[Response[F]] =
+    c.parFoldMapA(_.write004).map(makeResponse(_))
+
+  def routes[F[_]: Sync](
+    cr: CollectorRegistry[F]
+  ): HttpRoutes[F] = {
     val dsl = new Http4sDsl[F]{}; import dsl._
     HttpRoutes.of[F] {
       case GET -> Root / "metrics" => response(cr)
+    }
+  }
+
+  def routes[F[_]: Sync, T[_]: Foldable](
+    c: T[CollectorRegistry[F]]
+  ): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F]{}; import dsl._
+    HttpRoutes.of[F] {
+      case GET -> Root / "metrics" => response(c)
+    }
+  }
+
+  def routesPar[F[_]: Sync, T[_]: Foldable](
+    c: T[CollectorRegistry[F]]
+  )(implicit p: Parallel[F]
+  ): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F]{}; import dsl._
+    HttpRoutes.of[F] {
+      case GET -> Root / "metrics" => responsePar(c)
     }
   }
 }


### PR DESCRIPTION
Support for using multiple registries to publish for Scrapes.

Scenario, when it could be needed:
* application is using custom repository;
* some third party library is using specific logger and there is metrics exporter for this logger, which publishes to default only (they are available for many popular loggers);
* need to expose both application and logger metrics.

I also added `withContentType` to responses, so, the response's Content-Type will be exactly as it is recommended by standard.

PS. I could not figure out what formatting I should apply, because there is not much code in this repository. Feel free to adjust it as needed or give me a hint and I will update PR.